### PR TITLE
support read(data::Vector{UInt8})

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -48,6 +48,7 @@ end
 invalid(T, b) = ArgumentError("invalid JSON detected parsing type '$T': encountered '$(Char(b))'")
 
 read(str::AbstractString, T=Any, args...) = read(IOBuffer(str), T, args...)
+read(data::Vector{UInt8}, T=Any, args...) = read(IOBuffer(data), T, args...)
 
 # read generic JSON: detect null, Bool, Int, Float, String, Array, Dict/Object into a NamedTuple
 function read(io::IO, ::Type{Any}=Any)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,3 +177,17 @@ JSON2.pretty(io, json)
 
 @test_throws ArgumentError JSON2.read("a", Char)
 @test_throws ArgumentError JSON2.read("\"abc\"", Char)
+
+# test read(data::Vector{UInt8})
+@test JSON2.read(Vector{UInt8}("")) == NamedTuple()
+@test JSON2.read(Vector{UInt8}("{\"hey\":1}")) == (hey=1,)
+@test JSON2.read(Vector{UInt8}("[\"hey\",1]")) == ["hey",1]
+@test JSON2.read(Vector{UInt8}("1.0")) === 1
+@test JSON2.read(Vector{UInt8}("1")) === 1
+@test JSON2.read(Vector{UInt8}("1.1")) === 1.1
+@test JSON2.read(Vector{UInt8}("+1.1")) === 1.1
+@test JSON2.read(Vector{UInt8}("-1.1")) === -1.1
+@test JSON2.read(Vector{UInt8}("\"hey\"")) == "hey"
+@test JSON2.read(Vector{UInt8}("null")) === nothing
+@test JSON2.read(Vector{UInt8}("true")) === true
+@test JSON2.read(Vector{UInt8}("false")) === false


### PR DESCRIPTION
It's probably nice to support `read(data::Vector{UInt8})`.

benchmark
```
julia> @btime JSON2.read("{\"hey\":1}")
  2.112 μs (17 allocations: 944 bytes)
(hey = 1,)

julia> @btime JSON2.read(String([0x7b, 0x22, 0x68, 0x65, 0x79, 0x22, 0x3a, 0x31, 0x7d]))
  2.217 μs (19 allocations: 1.05 KiB)
(hey = 1,)
```

```
julia> @btime JSON2.read([0x7b, 0x22, 0x68, 0x65, 0x79, 0x22, 0x3a, 0x31, 0x7d])
  2.124 μs (17 allocations: 976 bytes)
(hey = 1,)
```