### PR TITLE
Fix performance regression from recent plumbing of kwargs through all…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.3.0"
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Parsers = "≥ 0.3.1"

--- a/src/JSON2.jl
+++ b/src/JSON2.jl
@@ -115,8 +115,8 @@ macro format(T, exprs...)
     else
         length(exprs) - 1, exprs[end]
     end
-    kwargs = Expr(:tuple, exprs[1:kwend]...)
-    kw = if !isempty(kwargs)
+    kw = if kwend > 0
+        kwargs = Expr(:tuple, exprs[1:kwend]...)
         :(JSON2.defaultkwargs(::Type{$T}) = $kwargs)
     end
 


### PR DESCRIPTION
… read calls. The problem is we were using a Dict for pass/merge keyword args everywhere which is much slower and not compiler friendly than using NamedTuples

cc @christopher-dG 