### PR TITLE
Mention JSON3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 |:---------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
 |[![][pkg-0.6-img]][pkg-0.6-url] | [![][travis-img]][travis-url] [![][codecov-img]][codecov-url] |
 
+This package is deprecated. Its successor is at [JSON3.jl](https://github.com/quinnj/JSON3.jl).
 
 ## Installation
 


### PR DESCRIPTION
I found out that JSON2 can spend ages (>20 minutes in my case) on precompilation a relatively small dataset. This PR suggests to point users to JSON3 because it's much quicker and, if I understand [[ANN] JSON3.jl](https://discourse.julialang.org/t/ann-json3-jl-yet-another-json-package-for-julia/25625/2) correctly, JSON2 is hard to maintain as well.