### PR TITLE
Fix don't warn in `mergedefaultkwargs` function that to use values(kwargs) in Julia 1.7

### DIFF
--- a/src/JSON2.jl
+++ b/src/JSON2.jl
@@ -16,7 +16,7 @@ include("pretty.jl")
 
 defaultkwargs(x::T) where T = defaultkwargs(T)
 defaultkwargs(x::Type) = NamedTuple()
-mergedefaultkwargs(x; kwargs...) = merge(defaultkwargs(x), kwargs.data)
+mergedefaultkwargs(x; kwargs...) = merge(defaultkwargs(x), values(kwargs))
 
 ## JSON2.@format
 function getformats(nm; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,3 +186,5 @@ JSON2.pretty(io, json)
 
 # Unions which both read strings
 @test JSON2.read("\"foo\"", Union{DateTime, String}) == "foo"
+
+@test_nowarn JSON2.mergedefaultkwargs(NamedTuple)


### PR DESCRIPTION
it's deprecated in https://github.com/JuliaLang/julia/blob/v1.7.0-beta4/base/deprecated.jl#L256

```
julia> using JSON2

julia> JSON2.mergedefaultkwargs(NamedTuple)
┌ Warning: use values(kwargs) and keys(kwargs) instead of kwargs.data and kwargs.itr
│   caller = #mergedefaultkwargs#79 at JSON2.jl:19 [inlined]
└ @ Core ~/.julia/dev/JSON2/src/JSON2.jl:19
NamedTuple()
```

```
julia> VERSION
v"1.8.0-DEV.542"
```