### PR TITLE
Add Parsers v2 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Parsers = "1"
+Parsers = "1, 2"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Add Parsers v2 compatibility -- the current Parsers v1 requirement blocks updating to the latest CSV v0.85 with packages with JSON2.jl as a dependency such as Dash